### PR TITLE
fix mysql_connector_java_tarball_url

### DIFF
--- a/ansible/roles/mysql_connector_java/defaults/main.yml
+++ b/ansible/roles/mysql_connector_java/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 mysql_connector_java_version: "5.1.38"
 mysql_connector_java_tarball_file: mysql-connector-java-{{ mysql_connector_java_version }}.tar.gz
-mysql_connector_java_tarball_url: http://cdn.mysql.com/Downloads/Connector-J/{{ mysql_connector_java_tarball_file }}
+mysql_connector_java_tarball_url: https://dev.mysql.com/get/Downloads/Connector-J/{{ mysql_connector_java_tarball_file }}
 mysql_connector_java_download_dir: /tmp
 mysql_connector_java_install_dir: /opt/mysql-connector-java
 mysql_connector_java_archive: "{{ mysql_connector_java_download_dir }}/{{ mysql_connector_java_tarball_file }}"


### PR DESCRIPTION
```
TASK [mysql_connector_java : download mysql-connector-java] ********************
fatal: [192.168.33.50]: FAILED! => {"changed": false, "dest": "/tmp/mysql-connector-java-5.1.38.tar.gz", "failed": true, "msg": "Request failed", "response": "HTTP Error 404: Not Found", "state": "absent", "status_code": 404, "url": "http://cdn.mysql.com/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz"}
```

The latest mysql-connector-java tarball is placed under `http://cdn.mysql.com//Downloads`, while older versions are moved to `http://cdn.mysql.com//archives`.

Bumping the version from 5.1.38 to 5.1.40 will fix this problem for now, but it may brake again.
So I changed the host of `mysql_connector_java_tarball_url` from `cdn.mysql.com` to `dev.mysql.com`.
This URL should redirect to the right URL. 😸 

```
[shuji@koike] $ curl -IL https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz
HTTP/1.1 302 Found
Date: Thu, 03 Nov 2016 03:39:18 GMT
Server: Apache
X-Frame-Options: SAMEORIGIN
Set-Cookie: MySQL_S=1h776n3k0atvg314unllkl3poaa0fei2; path=/; domain=mysql.com; HttpOnly
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Pragma: no-cache
Location: http://cdn.mysql.com//archives/mysql-connector-java-5.1/mysql-connector-java-5.1.38.tar.gz
Vary: Accept-Encoding
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Type: text/html; charset=UTF-8

HTTP/1.1 200 OK
Server: Apache
ETag: "8f8e768a91338328f2ac5cd6b6683c88:1462815833"
Last-Modified: Wed, 02 Dec 2015 07:02:15 GMT
Accept-Ranges: bytes
Content-Length: 3938241
Date: Thu, 03 Nov 2016 03:39:20 GMT
Connection: keep-alive
Content-Type: application/x-tar-gz

[shuji@koike] $ curl -IL https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.40.tar.gz
HTTP/1.1 302 Found
Date: Thu, 03 Nov 2016 03:47:49 GMT
Server: Apache
X-Frame-Options: SAMEORIGIN
Set-Cookie: MySQL_S=m9vm5qpiraj2103hs509e01ci5eb519e; path=/; domain=mysql.com; HttpOnly
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Pragma: no-cache
Location: http://cdn.mysql.com//Downloads/Connector-J/mysql-connector-java-5.1.40.tar.gz
Vary: Accept-Encoding
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Type: text/html; charset=UTF-8

HTTP/1.1 200 OK
Server: Apache
ETag: "415a375cf8a096ef0aa775a4ae36916d:1475514019"
Last-Modified: Sat, 24 Sep 2016 16:35:06 GMT
Accept-Ranges: bytes
Content-Length: 3911557
Date: Thu, 03 Nov 2016 03:47:50 GMT
Connection: keep-alive
Content-Type: application/x-tar-gz
```

