### PR TITLE
use get_url module rather than running wget

### DIFF
--- a/ansible/roles/oracle_jdk/tasks/main.yml
+++ b/ansible/roles/oracle_jdk/tasks/main.yml
@@ -12,7 +12,11 @@
   when: jdk_archive_check.stat.exists and java_home_check.stat.size == 0
 
 - name: download Java
-  command: "wget -q -O {{ jdk_archive }} --no-check-certificate --no-cookies --header 'Cookie: oraclelicense=accept-securebackup-cookie' {{ jdk_tarball_url }} creates={{ jdk_archive }}"
+  get_url:
+    url: "{{ jdk_tarball_url }}"
+    dest: "{{ jdk_archive }}"
+    headers: 'Cookie: oraclelicense=accept-securebackup-cookie'
+    validate_certs: no
   when: java_home_check.stat.exists == False
 
 - name: create java_install_dir if not exists


### PR DESCRIPTION
This change removes the warning:
```
TASK [oracle_jdk : download Java] **********************************************

changed: [192.168.33.50]

 [WARNING]: Consider using get_url or uri module rather than running wget
```